### PR TITLE
O tipo do kit muda de "letra" para "VAZIO" quando workmaps acabam

### DIFF
--- a/models/kit.js
+++ b/models/kit.js
@@ -196,7 +196,7 @@ class Kit {
    */
   static update(id, kit) {
     return new Promise((resolve, reject) => {
-      if(kit.mapArray.length - 1 === kit.toxinaStart){
+      if(kit.mapArray.length === kit.toxinaStart){
         kit.kitType = "VAZIO";
       }
       KitModel.findByIdAndUpdate(id, kit).then((res) => {

--- a/routes/stock.js
+++ b/routes/stock.js
@@ -29,6 +29,11 @@ function datavalida(d1, m1, a1, d2, m2, a2) {
 /* GET home page. */
 router.get('/', auth.isAuthenticated, function (req, res, next) {
   Kit.getAll().then((kits) => {
+    if (kits && kits.length > 0){
+      kits.forEach(element => {
+        Kit.update(element._id, element);
+      });
+    }
     Kitstock.getAll().then((kitstocks) => {
       var today = new Date();
       var kit90 = new Array;


### PR DESCRIPTION
Essa mudança acontece quando se acessa a página do estoque. Setar o tipo como vazio possibilita a criação de um novo kit com o tipo antigo do kit que acabou de atualizar.